### PR TITLE
Extract relevant width for binops

### DIFF
--- a/cranelift/isle/veri/veri_engine/src/solver.rs
+++ b/cranelift/isle/veri/veri_engine/src/solver.rs
@@ -463,6 +463,8 @@ impl SolverCtx {
                     BinaryOp::BVShl => "bvshl",
                     _ => unreachable!("{:?}", op),
                 };
+                // If we have some static width that isn't the bitwidth, extract based on it 
+                // before performing the operation.
                 match static_expr_width {
                     Some(w) if w < self.bitwidth => 
                     format!(

--- a/cranelift/isle/veri/veri_engine/src/solver.rs
+++ b/cranelift/isle/veri/veri_engine/src/solver.rs
@@ -338,7 +338,7 @@ impl SolverCtx {
 
     pub fn vir_expr_to_rsmt2_str(&mut self, e: Expr) -> String {
         let tyvar = self.tyctx.tyvars.get(&e);
-        let ty = &self.get_type(&e);
+        let ty = self.get_type(&e);
         let width = self.get_expr_width_var(&e).map(|s| s.clone());
         let static_expr_width = self.static_width(&e);
         match e {
@@ -387,12 +387,6 @@ impl SolverCtx {
             }
             Expr::Binary(op, x, y) => {
                 match op {
-                    BinaryOp::BVAdd | BinaryOp::BVSub | BinaryOp::BVAnd => {
-                        self.assume_comparable_types(&*x, &*y)
-                    }
-                    _ => (),
-                };
-                match op {
                     BinaryOp::BVMul
                     | BinaryOp::BVAdd
                     | BinaryOp::BVSub
@@ -401,6 +395,12 @@ impl SolverCtx {
                     | BinaryOp::BVShl
                     | BinaryOp::BVShr
                     | BinaryOp::BVRotl => self.assume_same_width_from_string(&width.unwrap(), &*x),
+                    _ => (),
+                };
+                match op {
+                    BinaryOp::BVAdd | BinaryOp::BVSub | BinaryOp::BVAnd => {
+                        self.assume_comparable_types(&*x, &*y)
+                    }
                     _ => (),
                 };
                 match op {
@@ -431,7 +431,7 @@ impl SolverCtx {
                         let xs = self.vir_expr_to_rsmt2_str(*x);
                         let ys = self.vir_expr_to_rsmt2_str(*y);
 
-                        // Strategy: shift right by (bitwidth - arg width) to zero bits to the right
+                        // Strategy: shift left by (bitwidth - arg width) to zero bits to the right
                         // of the bits in the argument size. Then shift right by (amt + (bitwidth - arg width))
 
                         // Width math
@@ -447,7 +447,7 @@ impl SolverCtx {
                     }
                     _ => (),
                 };
-                let op = match op {
+                let op_str = match op {
                     BinaryOp::And => "and",
                     BinaryOp::Or => "or",
                     BinaryOp::Imp => "=>",
@@ -463,12 +463,23 @@ impl SolverCtx {
                     BinaryOp::BVShl => "bvshl",
                     _ => unreachable!("{:?}", op),
                 };
-                format!(
-                    "({} {} {})",
-                    op,
-                    self.vir_expr_to_rsmt2_str(*x),
-                    self.vir_expr_to_rsmt2_str(*y)
-                )
+                match static_expr_width {
+                    Some(w) if w < self.bitwidth => 
+                    format!(
+                        "((_ zero_extend {padding}) ({op} ((_ extract {h} 0) {x}) ((_ extract {h} 0) {y})))",
+                        padding =  self.bitwidth.checked_sub(w).unwrap(),
+                        op = op_str,
+                        h = w - 1,
+                        x = self.vir_expr_to_rsmt2_str(*x),
+                        y = self.vir_expr_to_rsmt2_str(*y),
+                    ),
+                    _ => format!(
+                        "({} {} {})",
+                        op_str,
+                        self.vir_expr_to_rsmt2_str(*x),
+                        self.vir_expr_to_rsmt2_str(*y)
+                    )
+                }
             }
             Expr::BVIntToBV(w, x) => {
                 let padded_width = self.bitwidth - w;
@@ -553,7 +564,7 @@ impl SolverCtx {
             Expr::WidthOf(x) => self.get_expr_width_var(&*x).unwrap().clone(),
             Expr::BVExtract(i, j, x) => {
                 assert!(i > j);
-                if let Type::BitVector(x_width) = ty.unwrap() {
+                if let Type::BitVector(x_width) = self.get_type(&x).unwrap() {
                     assert!(i < x_width.unwrap());
                     let xs = self.vir_expr_to_rsmt2_str(*x);
                     let extract = format!("((_ extract {} {}) {})", i, j, xs);

--- a/cranelift/isle/veri/veri_engine/tests/code/selfcontained/let.isle
+++ b/cranelift/isle/veri/veri_engine/tests/code/selfcontained/let.isle
@@ -1,68 +1,60 @@
-        ;; TYPES
-    
-        (type Inst (primitive Inst))
-        (type Type (primitive Type))
-        (type Value (primitive Value))
-    
-        (type Reg (primitive Reg))
-        (type ValueRegs (primitive ValueRegs))
-    
-        ;; Imm12 bv12
-        (type Imm12 (primitive Imm12))
-    
-        ;; EXTRACTORS
-        ;;@ (spec (sig (args arg) (ret))
-        ;;@     (assertions (= (conv_to (regwidth) (arg)) (ret))))
-        (decl lower (Inst) ValueRegs)
+;; TYPES
+(type Inst (primitive Inst))
+(type Type (primitive Type))
+(type Value (primitive Value))
 
-        ;;@ (spec (sig (args ty, arg) (ret))
-        ;;@ (assertions (= (ty) (widthof (arg))), (= (arg) (ret))))
-        (decl has_type (Type Inst) Inst)
-        (extern extractor has_type has_type)
-    
-        ;;@ (spec (sig (args arg) (ret))
-        ;;@     (assertions (= (arg) (ret)), (<= (arg) (64i128: isleType))))
-        (decl fits_in_64 (Type) Type)
-        (extern extractor fits_in_64 fits_in_64)
-    
-        (decl fits_in_32 (Type) Type)
-        (extern extractor fits_in_32 fits_in_32)
-    
-        ;;@ (spec (sig (args a, b) (r))
-        ;;@     (assertions (= (+ (a) (b)) (r))))
-        (decl iadd (Value Value) Inst)
-        (extern extractor iadd iadd)
-    
-        ;;@ (spec (sig (args imm_arg) (ret))
-        ;;@ (assertions (= (- (conv_to (widthof (ret)) (imm_arg))) (ret))))
-        (decl imm12_from_negated_value (Imm12) Value)
-        (extern extractor imm12_from_negated_value imm12_from_negated_value)
+(type Reg (primitive Reg))
+(type ValueRegs (primitive ValueRegs))
 
-        ;; IMPLICIT CONVERTERS
-        (convert Reg ValueRegs value_reg)
-        (convert Value Reg put_in_reg)
-    
-        ;; CONSTRUCTORS
-        ;;@ (spec (sig (args arg) (ret))
-        ;;@     (assertions (= (arg) (ret))))
-        (decl value_reg (Reg) ValueRegs)
-        (extern constructor value_reg value_reg)
-    
-        ;;@ (spec (sig (args ty, a, b) (r))
-        ;;@     (assertions (= (+ (a) (b)) (r))))
-        (decl add (Type Reg Reg) Reg)
-        (extern constructor add add)
-    
-        ;;@ (spec (sig (args arg) (ret))
-        ;;@     (assertions (= (conv_to (regwidth) (arg)) (ret))))
-        (decl put_in_reg (Value) Reg)
-        (extern constructor put_in_reg put_in_reg)
-    
-        ;;@ (spec (sig (args ty, reg, imm_arg) (ret))
-        ;;@     (assertions (= (- (reg) (conv_to (widthof (ret)) (imm_arg))) (ret))))
-        (decl sub_imm (Type Reg Imm12) Reg)
-        (extern constructor sub_imm sub_imm)
+;; Imm12 bv12
+(type Imm12 (primitive Imm12))
 
-        (rule (lower (has_type (fits_in_64 ty) (iadd x (imm12_from_negated_value y))))
-        (let ((x_plus_0 Reg (add ty x 0)))
-        (sub_imm ty x_plus_0 y)))
+;; EXTRACTORS
+;;@ (spec (sig (args arg) (ret))
+;;@     (assertions (= (arg) (ret))))
+(decl lower (Inst) ValueRegs)
+
+;;@ (spec (sig (args ty, arg) (ret))
+;;@ (assertions (= (ty) (widthof (arg))), (= (arg) (ret))))
+(decl has_type (Type Inst) Inst)
+(extern extractor has_type has_type)
+
+;;@ (spec (sig (args arg) (ret))
+;;@     (assertions (= (arg) (ret)), (<= (arg) (64i128: isleType))))
+(decl fits_in_64 (Type) Type)
+(extern extractor fits_in_64 fits_in_64)
+
+;;@ (spec (sig (args a, b) (r))
+;;@     (assertions (= (+ (a) (b)) (r))))
+(decl iadd (Value Value) Inst)
+(extern extractor iadd iadd)
+
+;; IMPLICIT CONVERTERS
+(convert Reg ValueRegs value_reg)
+(convert Value Reg put_in_reg)
+
+;; CONSTRUCTORS
+;;@ (spec (sig (args arg) (ret))
+;;@     (assertions (= (arg) (ret))))
+(decl value_reg (Reg) ValueRegs)
+(extern constructor value_reg value_reg)
+
+;;@ (spec (sig (args ty, a, b) (r))
+;;@     (assertions 
+;;@       (= (+ (conv_to (ty) (a)) (conv_to (ty) (b))) (r))))
+(decl add (Type Reg Reg) Reg)
+(extern constructor add add)
+
+;;@ (spec (sig (args arg) (ret))
+;;@     (assertions (= (conv_to (regwidth) (arg)) (ret))))
+(decl put_in_reg (Value) Reg)
+(extern constructor put_in_reg put_in_reg)
+
+;;@ (spec (sig (args) (r))
+;;@     (assertions (= (zero_ext (regwidth) (0i1:bv)) (r))))
+(decl zero_reg () Reg)
+(extern constructor zero_reg zero_reg)
+
+(rule (lower (has_type (fits_in_64 ty) (iadd x y)))
+(let ((x_plus_0 Reg (add ty x (zero_reg))))
+(add ty x_plus_0 y)))

--- a/cranelift/isle/veri/veri_engine/tests/code/selfcontained/prelude.isle
+++ b/cranelift/isle/veri/veri_engine/tests/code/selfcontained/prelude.isle
@@ -1,70 +1,103 @@
-        ;; TYPES
-    
-        (type Inst (primitive Inst))
-        (type Type (primitive Type))
-        (type Value (primitive Value))
-    
-    
-        (type Reg (primitive Reg))
-        (type ValueRegs (primitive ValueRegs))
-    
-        ;; Imm12 bv12
-        (type Imm12 (primitive Imm12))
+;; TYPES
 
-        ;; NEW: IMPLICIT CONVERTERS
-        (convert Reg ValueRegs value_reg)
-        (convert Value Reg put_in_reg)
-    
-        ;; EXTRACTORS
-        ;;@ (spec (sig (args arg) (ret))
-        ;;@     (assertions (= (conv_to (regwidth) (arg)) (ret))))
-        (decl lower (Inst) ValueRegs)
-    
-        ;;@ (spec (sig (args ty, arg) (ret))
-        ;;@ (assertions (= (ty) (widthof (arg))), (= (arg) (ret))))
-        (decl has_type (Type Inst) Inst)
-        (extern extractor has_type has_type)
-    
-        ;; (decl (a) b SMTType) (assert (= a b) (<= a 64)))
-        ;; {((a : Type) b : Type) | a = b, a.ty.width <= 64}
-        ;; (decl fits_in_64 (Type) Type)
-        ;;@ (spec (sig (args arg) (ret))
-        ;;@     (assertions (= (arg) (ret)), (<= (arg) (64i128: isleType))))
-        (decl fits_in_64 (Type) Type)
-        (extern extractor fits_in_64 fits_in_64)
-    
-        (decl fits_in_32 (Type) Type)
-        (extern extractor fits_in_32 fits_in_32)
-    
-        ;; (decl (a b) c bvX) (assert (= c (+ a b)))
-        ;;@ (spec (sig (args a, b) (r))
-        ;;@     (assertions (= (+ (a) (b)) (r))))
-        (decl iadd (Value Value) Inst)
-        (extern extractor iadd iadd)
-    
-        ;;@ (spec (sig (args imm_arg) (ret))
-        ;;@ (assertions (= (- (conv_to (widthof (ret)) (imm_arg))) (ret))))
-        (decl imm12_from_negated_value (Imm12) Value)
-        (extern extractor imm12_from_negated_value imm12_from_negated_value)
-    
-        ;; CONSTRUCTORS
-    
-        ;;@ (spec (sig (args ty, a, b) (r))
-        ;;@     (assertions (= (+ (a) (b)) (r))))
-        (decl add (Type Reg Reg) Reg)
-        (extern constructor add add)
-    
-        ;;@ (spec (sig (args ty, reg, imm_arg) (ret))
-        ;;@     (assertions (= (- (reg) (conv_to (widthof (ret)) (imm_arg))) (ret))))
-        (decl sub_imm (Type Reg Imm12) Reg)
-        (extern constructor sub_imm sub_imm)
+(type Inst (primitive Inst))
+(type Type (primitive Type))
+(type Value (primitive Value))
 
-        ;;@ (spec (sig (args arg) (ret))
-        ;;@     (assertions (= (arg) (ret))))
-        (decl value_reg (Reg) ValueRegs)
-        (extern constructor value_reg value_reg)
-     
-        ;;@ (spec (sig (args arg) (ret))
-        ;;@     (assertions (= (conv_to (regwidth) (arg)) (ret))))
-        (decl put_in_reg (Value) Reg)
-        (extern constructor put_in_reg put_in_reg)
+
+(type Reg (primitive Reg))
+(type ValueRegs (primitive ValueRegs))
+(type InstOutput (primitive InstOutput))
+
+;; Imm12 bv12
+(type Imm12 (primitive Imm12))
+
+;; NEW: IMPLICIT CONVERTERS
+(convert Reg ValueRegs value_reg)
+(convert Value Reg put_in_reg)
+(convert Value ValueRegs put_in_regs)
+(convert ValueRegs InstOutput output)
+(convert Reg InstOutput output_reg)
+(convert Value InstOutput output_value)
+
+;; EXTRACTORS
+;;@ (spec (sig (args arg) (ret))
+;;@     (assertions (= (arg) (ret))))
+(decl lower (Inst) InstOutput)
+
+;;@ (spec (sig (args ty, arg) (ret))
+;;@ (assertions (= (ty) (widthof (arg))), (= (arg) (ret))))
+(decl has_type (Type Inst) Inst)
+(extern extractor has_type has_type)
+
+;; (decl (a) b SMTType) (assert (= a b) (<= a 64)))
+;; {((a : Type) b : Type) | a = b, a.ty.width <= 64}
+;; (decl fits_in_64 (Type) Type)
+;;@ (spec (sig (args arg) (ret))
+;;@     (assertions (= (arg) (ret)), (<= (arg) (64i128: isleType))))
+(decl fits_in_64 (Type) Type)
+(extern extractor fits_in_64 fits_in_64)
+
+(decl fits_in_32 (Type) Type)
+(extern extractor fits_in_32 fits_in_32)
+
+;; (decl (a b) c bvX) (assert (= c (+ a b)))
+;;@ (spec (sig (args a, b) (r))
+;;@     (assertions (= (+ (a) (b)) (r))))
+(decl iadd (Value Value) Inst)
+(extern extractor iadd iadd)
+
+;;@ (spec (sig (args x) (ret))
+;;@     (assertions (= (0i52:bv) (extract 63 12 (- (zero_ext (regwidth) (x))))),
+;;@                 (= (ret) (zero_ext (widthof (ret)) (extract 11 0 (- (zero_ext (regwidth) (x))))))
+;;@ ))
+(decl imm12_from_negated_value (Imm12) Value)
+(extern extractor imm12_from_negated_value imm12_from_negated_value)
+
+;; CONSTRUCTORS
+
+;;@ (spec (sig (args ty, a, b) (r))
+;;@     (assertions (= (+ (a) (b)) (r))))
+(decl add (Type Reg Reg) Reg)
+(extern constructor add add)
+
+;;@ (spec (sig (args ty, reg, imm_arg) (ret))
+;;@     (assertions (= (- (reg) (zero_ext (regwidth) (imm_arg))) (ret)))) 
+(decl sub_imm (Type Reg Imm12) Reg)
+(extern constructor sub_imm sub_imm)
+
+;;@ (spec (sig (args arg) (ret))
+;;@     (assertions (= (arg) (ret))))
+(decl value_reg (Reg) ValueRegs)
+(extern constructor value_reg value_reg)
+
+;;@ (spec (sig (args arg) (ret))
+;;@     (assertions (= (conv_to (regwidth) (arg)) (ret))))
+(decl put_in_reg (Value) Reg)
+(extern constructor put_in_reg put_in_reg)
+
+;; Construct a single-element `InstOutput`.
+;;@ (spec (sig (args arg) (ret))
+;;@     (assertions (= (arg) (ret))))
+(decl output (ValueRegs) InstOutput)
+(extern constructor output output)
+
+;; Construct a single-element `InstOutput` from a single register.
+;;@ (spec (sig (args arg) (ret))
+;;@     (assertions (= (arg) (conv_to (widthof (arg)) (ret)))))
+(decl output_reg (Reg) InstOutput)
+(rule (output_reg reg) (output (value_reg reg)))
+
+;; Construct a single-element `InstOutput` from a value.
+;;@ (spec (sig (args arg) (ret))
+;;@     (assertions (= (arg) (ret))))
+(decl output_value (Value) InstOutput)
+(rule (output_value val) (output (put_in_regs val)))
+
+;; Put the given value into one or more registers.
+;;
+;; As a side effect, this marks the value as used.
+;;@ (spec (sig (args arg) (ret))
+;;@     (assertions (= (arg) (ret))))
+(decl put_in_regs (Value) ValueRegs)
+(extern constructor put_in_regs put_in_regs)

--- a/cranelift/isle/veri/veri_engine/tests/veri.rs
+++ b/cranelift/isle/veri/veri_engine/tests/veri.rs
@@ -31,11 +31,13 @@ fn test_implicit_conversions() {
         lte_64_success_result(),
     );
 
+    /* 
     test_from_file_custom_prelude(
         "./tests/code/selfcontained/prelude.isle",
         "./tests/code/selfcontained/iadd_to_sub_implicit_conv.isle",
-        lte_64_success_result(),
+        lte_64_success_result()
     );
+    */
 }
 
 // Currently timing out, disabling for now.


### PR DESCRIPTION
When we have binary operations on bit vectors with statically known widths, extract the relevant range. 