### PR TITLE
Fix type inference for enum variants

### DIFF
--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -201,7 +201,6 @@ pub struct TermEnv {
     /// types together.
     pub converters: StableMap<(TypeId, TypeId), TermId>,
 
-
     /// Flag for whether to expand internal extractors in the
     /// translation from the AST to sema.
     pub expand_internal_extractors: bool,
@@ -1165,7 +1164,11 @@ impl Bindings {
 
 impl TermEnv {
     /// Construct the term environment from the AST and the type environment.
-    pub fn from_ast(tyenv: &mut TypeEnv, defs: &ast::Defs, expand_internal_extractors: bool) -> Result<TermEnv, Errors> {
+    pub fn from_ast(
+        tyenv: &mut TypeEnv,
+        defs: &ast::Defs,
+        expand_internal_extractors: bool,
+    ) -> Result<TermEnv, Errors> {
         let mut env = TermEnv {
             terms: vec![],
             term_map: StableMap::new(),
@@ -2389,7 +2392,8 @@ impl TermEnv {
         Some(IfLet { lhs, rhs })
     }
 
-    fn get_term_by_name(&self, tyenv: &TypeEnv, sym: &ast::Ident) -> Option<TermId> {
+    /// Lookup term by name.
+    pub fn get_term_by_name(&self, tyenv: &TypeEnv, sym: &ast::Ident) -> Option<TermId> {
         tyenv
             .intern(sym)
             .and_then(|sym| self.term_map.get(&sym))

--- a/cranelift/isle/veri/veri_engine/src/solver.rs
+++ b/cranelift/isle/veri/veri_engine/src/solver.rs
@@ -1247,7 +1247,6 @@ impl SolverCtx {
                 .assert(self.smt.named(format!("assum{i}"), *a))
                 .unwrap();
 
-            // Uncomment to debug specific asserts
             // println!("assum{}: {}", i, self.smt.display(*a));
 
             //     self.smt.push().unwrap();
@@ -1790,7 +1789,7 @@ fn resolve_dynamic_widths(
                         }
 
                         if unresolved_widths.contains(&width_name) {
-                            // println!("\tResolved width: {}, {}", width_name, width_int);
+                            println!("\tResolved width: {}, {}", width_name, width_int);
                             width_resolutions.insert(width_name, width_int);
                             cur_tyctx
                                 .tymap

--- a/cranelift/isle/veri/veri_engine/src/verify.rs
+++ b/cranelift/isle/veri/veri_engine/src/verify.rs
@@ -23,7 +23,7 @@ pub fn verify_rules(inputs: Vec<PathBuf>, config: &Config) {
     // names to types
     let (typeenv, termenv) = create_envs(&defs).unwrap();
 
-    let annotation_env = parse_annotations(&defs, &typeenv);
+    let annotation_env = parse_annotations(&defs, &termenv, &typeenv);
 
     // Get the types/widths for this particular term
     let types = isle_inst_types()
@@ -33,7 +33,6 @@ pub fn verify_rules(inputs: Vec<PathBuf>, config: &Config) {
 
     for type_instantiation in types {
         let type_sols = type_rules_with_term_and_types(
-            defs.clone(),
             &termenv,
             &typeenv,
             &annotation_env,

--- a/cranelift/isle/veri/veri_engine/tests/utils/mod.rs
+++ b/cranelift/isle/veri/veri_engine/tests/utils/mod.rs
@@ -113,7 +113,7 @@ fn test_rules_with_term(inputs: Vec<PathBuf>, tr: TestResult, config: Config) ->
     let lexer = cranelift_isle::lexer::Lexer::from_files(&inputs).unwrap();
     let defs = cranelift_isle::parser::parse(lexer).expect("should parse");
     let (typeenv, termenv) = create_envs(&defs).unwrap();
-    let annotation_env = parse_annotations(&defs, &typeenv);
+    let annotation_env = parse_annotations(&defs, &termenv, &typeenv);
 
     let instantiations = match tr {
         TestResult::Simple(s) => {
@@ -149,7 +149,6 @@ fn test_rules_with_term(inputs: Vec<PathBuf>, tr: TestResult, config: Config) ->
     for (type_instantiation, expected_result) in instantiations {
         println!("Expected result: {:?}", expected_result);
         let type_sols = type_rules_with_term_and_types(
-            defs.clone(),
             &termenv,
             &typeenv,
             &annotation_env,
@@ -345,7 +344,7 @@ pub fn test_concrete_aarch64_rule_with_lhs_termname(
     let lexer = cranelift_isle::lexer::Lexer::from_files(&inputs).unwrap();
     let defs = cranelift_isle::parser::parse(lexer).expect("should parse");
     let (typeenv, termenv) = create_envs(&defs).unwrap();
-    let annotation_env = parse_annotations(&defs, &typeenv);
+    let annotation_env = parse_annotations(&defs, &termenv, &typeenv);
 
     let config = Config {
         dyn_width: dynwidth,
@@ -366,7 +365,6 @@ pub fn test_concrete_aarch64_rule_with_lhs_termname(
     };
 
     let type_sols = type_rules_with_term_and_types(
-        defs.clone(),
         &termenv,
         &typeenv,
         &annotation_env,
@@ -406,7 +404,7 @@ pub fn test_concrete_input_from_file_with_lhs_termname(
     let lexer = cranelift_isle::lexer::Lexer::from_files(&inputs).unwrap();
     let defs = cranelift_isle::parser::parse(lexer).expect("should parse");
     let (typeenv, termenv) = create_envs(&defs).unwrap();
-    let annotation_env = parse_annotations(&defs, &typeenv);
+    let annotation_env = parse_annotations(&defs, &termenv, &typeenv);
 
     let config = Config {
         dyn_width: dynwidth,
@@ -427,7 +425,6 @@ pub fn test_concrete_input_from_file_with_lhs_termname(
     };
 
     let type_sols = type_rules_with_term_and_types(
-        defs.clone(),
         &termenv,
         &typeenv,
         &annotation_env,


### PR DESCRIPTION
This PR proposes a fix for the type inference problem that was preventing verification of the Amode lowering with the expression `(Amode.ImmRegRegShift offset x y 0 flags)`.

https://github.com/avanhatt/wasmtime/blob/6e0a601361ac92db65de1413afab97e036cbed98/cranelift/codegen/src/isa/x64/inst.isle#L1130-L1131

The specific problem was a failure to deduce the type for the shift argument (set to the constant 0). I believe the root cause was with `add_isle_constraints` which was only considering declarations, not enum variants. I saw that the Sema layer in ISLE handles this already, so both declarations and enum variants are merged in the TermEnv. Therefore this PR changes `add_isle_constraints` to operate on Sema Terms rather than AST Decls. This has the (I think) nice side effect that type inference no longer uses any AST types. That also meant that the change had a bit of a larger blast radius, with various function signatures changing etc.
