### PR TITLE
veri: cargo fmt

### DIFF
--- a/cranelift/isle/veri/veri_engine/src/type_inference.rs
+++ b/cranelift/isle/veri/veri_engine/src/type_inference.rs
@@ -1402,7 +1402,10 @@ fn add_isle_constraints(
         ),
         ("OperandSize".to_owned(), annotation_ir::Type::Int),
         ("Reg".to_owned(), annotation_ir::Type::BitVector),
-        ("IntCC".to_owned(), annotation_ir::Type::BitVectorWithWidth(8)),
+        (
+            "IntCC".to_owned(),
+            annotation_ir::Type::BitVectorWithWidth(8),
+        ),
         ("Inst".to_owned(), annotation_ir::Type::BitVector),
         ("Amode".to_owned(), annotation_ir::Type::BitVector),
         ("Value".to_owned(), annotation_ir::Type::BitVector),

--- a/cranelift/isle/veri/veri_engine/tests/veri.rs
+++ b/cranelift/isle/veri/veri_engine/tests/veri.rs
@@ -1306,9 +1306,7 @@ fn test_broken_cls_8() {
         test_from_file_with_lhs_termname_simple(
             "./examples/broken/cls/broken_cls8.isle",
             "cls".to_string(),
-            vec![
-                (Bitwidth::I8, VerificationResult::Failure(Counterexample {})),
-            ],
+            vec![(Bitwidth::I8, VerificationResult::Failure(Counterexample {}))],
         )
     });
 }
@@ -1387,10 +1385,8 @@ fn test_broken_ctz_32_64() {
             "./examples/broken/ctz/broken_ctz.isle",
             "clz".to_string(),
             vec![
+                (Bitwidth::I8, VerificationResult::Failure(Counterexample {})),
                 (
-                    Bitwidth::I8,
-                    VerificationResult::Failure(Counterexample {}),
-                ),                (
                     Bitwidth::I16,
                     VerificationResult::Failure(Counterexample {}),
                 ),
@@ -1913,7 +1909,6 @@ fn test_named_bxor_fits_in_64() {
     })
 }
 
-
 #[test]
 fn test_named_band_not_right() {
     run_and_retry(|| {
@@ -2009,7 +2004,6 @@ fn test_named_bxor_not_left() {
         )
     })
 }
-
 
 #[test]
 fn test_named_bnot() {
@@ -3184,18 +3178,15 @@ fn test_broken_imm_udiv_cve_underlying() {
     })
 }
 
-
 #[test]
 fn test_broken_imm_udiv_cve_underlying_32() {
     // Since there are no bitvectors in the signature, need a custom assumption
     // hook to pass through the value of the type argument
     run_and_retry(|| {
-        static EXPECTED: [(Bitwidth, VerificationResult); 1] = [
-            (
-                Bitwidth::I32,
-                VerificationResult::Failure(Counterexample {}),
-            ),
-        ];
+        static EXPECTED: [(Bitwidth, VerificationResult); 1] = [(
+            Bitwidth::I32,
+            VerificationResult::Failure(Counterexample {}),
+        )];
         for (ty, result) in &EXPECTED {
             let config = Config {
                 dyn_width: false,

--- a/cranelift/isle/veri/veri_ir/src/annotation_ir.rs
+++ b/cranelift/isle/veri/veri_ir/src/annotation_ir.rs
@@ -193,7 +193,6 @@ pub enum Expr {
     A64Rev(Box<Expr>, Box<Expr>, u32),
     BVPopcnt(Box<Expr>, u32),
 
-
     // Binary operators
     BVMul(Box<Expr>, Box<Expr>, u32),
     BVUDiv(Box<Expr>, Box<Expr>, u32),
@@ -226,7 +225,7 @@ pub enum Expr {
     // Extract specified bits
     BVExtract(usize, usize, Box<Expr>, u32),
 
-    // Concat two bitvectors 
+    // Concat two bitvectors
     BVConcat(Vec<Expr>, u32),
 
     // Convert integer to bitvector
@@ -318,7 +317,7 @@ impl Expr {
             | Expr::BVSubs(_, _, _, t)
             | Expr::BVPopcnt(_, t)
             | Expr::Conditional(_, _, _, t)
-            | Expr::Switch(_, _, t)  => *t,
+            | Expr::Switch(_, _, t) => *t,
         }
     }
 }


### PR DESCRIPTION
Applies `cargo fmt` to files under the `cranelift/isle/veri` tree.
