### PR TITLE
veri: verify some x64 amode rules

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1013,6 +1013,8 @@
 (decl synthetic_amode_to_reg_mem (SyntheticAmode) RegMem)
 (extern constructor synthetic_amode_to_reg_mem synthetic_amode_to_reg_mem)
 
+;; TODO(mbm): what is the right spec for amode_to_synthetic_amode?
+(spec (amode_to_synthetic_amode amode) (provide (= result amode)))
 (decl amode_to_synthetic_amode (Amode) SyntheticAmode)
 (extern constructor amode_to_synthetic_amode amode_to_synthetic_amode)
 
@@ -1036,6 +1038,33 @@
              ;; that the resulting immediate makes this Amode refer to
              ;; the given MachLabel.
              (RipRelative (target MachLabel))))
+
+;; Model an Amode as a calculated 64-bit address.
+;; TODO: what is the right model for Amode?
+;; TODO: represent flags in Amode
+(model Amode (type (bv 64)))
+
+;; TODO: represent flags in Amode
+(spec (Amode.ImmReg simm base flags)
+      (provide (= result (bvadd base (sign_ext 64 simm))))
+      (require
+        (= (widthof simm) 32)
+        (= (widthof base) 64)
+        (= (widthof flags) 8)))
+
+;; TODO: represent flags in Amode
+(spec (Amode.ImmRegRegShift simm base index shift flags)
+  (provide
+    (= result
+      (bvadd
+        (bvadd base (sign_ext 64 simm))
+        (bvshl index (zero_ext 64 shift)))))
+  (require
+       (= (widthof simm) 32)
+       (= (widthof base) 64)
+       (= (widthof index) 64)
+       (= (widthof shift) 8)
+       (= (widthof flags) 8)))
 
 ;; A helper to both check that the `Imm64` and `Offset32` values sum to less
 ;; than 32-bits AND return this summed `u32` value. Also, the `Imm64` will be
@@ -1094,45 +1123,64 @@
 ;;
 ;; In other words this function's job is to find constants and then defer to
 ;; `amode_imm_reg*`.
+;;
+;; TODO: semantics of offset (sign extend or zero extend)?
+(spec (to_amode_add flags x y offset)
+      (provide (= result (bvadd (bvadd x y) (sign_ext 64 offset))))
+      (require
+            (= (widthof x) 64)
+            (= (widthof y) 64)))
 (decl to_amode_add (MemFlags Value Value Offset32) Amode)
 
-(rule 0 (to_amode_add flags x y offset)
+(rule to_amode_add_base_case 0 (to_amode_add flags x y offset)
         (amode_imm_reg_reg_shift flags x y offset))
-(rule 1 (to_amode_add flags x (iconst (simm32 c)) offset)
+(rule to_amode_add_const_rhs 1 (to_amode_add flags x (iconst (simm32 c)) offset)
         (if-let sum (s32_add_fallible offset c))
         (amode_imm_reg flags x sum))
-(rule 2 (to_amode_add flags (iconst (simm32 c)) x offset)
+(rule to_amode_add_const_lhs 2 (to_amode_add flags (iconst (simm32 c)) x offset)
         (if-let sum (s32_add_fallible offset c))
         (amode_imm_reg flags x sum))
-(rule 3 (to_amode_add flags (iadd x (iconst (simm32 c))) y offset)
+(rule to_amode_add_const_fold_iadd_lhs_rhs 3 (to_amode_add flags (iadd x (iconst (simm32 c))) y offset)
         (if-let sum (s32_add_fallible offset c))
         (amode_imm_reg_reg_shift flags x y sum))
-(rule 4 (to_amode_add flags (iadd (iconst (simm32 c)) x) y offset)
+(rule to_amode_add_const_fold_iadd_lhs_lhs 4 (to_amode_add flags (iadd (iconst (simm32 c)) x) y offset)
         (if-let sum (s32_add_fallible offset c))
         (amode_imm_reg_reg_shift flags x y sum))
-(rule 5 (to_amode_add flags x (iadd y (iconst (simm32 c))) offset)
+(rule to_amode_add_const_fold_iadd_rhs_rhs 5 (to_amode_add flags x (iadd y (iconst (simm32 c))) offset)
         (if-let sum (s32_add_fallible offset c))
         (amode_imm_reg_reg_shift flags x y sum))
-(rule 6 (to_amode_add flags x (iadd (iconst (simm32 c)) y) offset)
+(rule to_amode_add_const_fold_iadd_rhs_lhs 6 (to_amode_add flags x (iadd (iconst (simm32 c)) y) offset)
         (if-let sum (s32_add_fallible offset c))
         (amode_imm_reg_reg_shift flags x y sum))
 
 ;; Final cases of amode lowering. Does not hunt for constants and only attempts
 ;; to pattern match add-of-shifts to generate fancier `ImmRegRegShift` modes,
 ;; otherwise falls back on `ImmReg`.
+(spec (amode_imm_reg flags x offset)
+      (provide (= result (bvadd x (sign_ext 64 offset))))
+      (require
+            (= (widthof x) 64)))
 (decl amode_imm_reg (MemFlags Value Offset32) Amode)
-(rule 0 (amode_imm_reg flags base offset)
+(rule amode_imm_reg_base 0 (amode_imm_reg flags base offset)
         (Amode.ImmReg offset base flags))
-(rule 1 (amode_imm_reg flags (iadd x y) offset)
+(rule amode_imm_reg_iadd 1 (amode_imm_reg flags (iadd x y) offset)
         (amode_imm_reg_reg_shift flags x y offset))
 
+(spec (amode_imm_reg_reg_shift flags x y offset)
+      (provide (= result (bvadd (bvadd x y) (sign_ext 64 offset))))
+      (require
+            (= (widthof flags) 8)
+            (= (widthof x) 64)
+            (= (widthof y) 64)
+            (= (widthof offset) 32)))
 (decl amode_imm_reg_reg_shift (MemFlags Value Value Offset32) Amode)
-(rule 0 (amode_imm_reg_reg_shift flags x y offset)
+;; TODO: why does this fail to verify? the 0 constant is deduced to have width 1 when 8 is required
+(rule amode_imm_reg_reg_shift_no_shift 0 (amode_imm_reg_reg_shift flags x y offset)
         (Amode.ImmRegRegShift offset x y 0 flags)) ;; 0 == y<<0 == "no shift"
-(rule 1 (amode_imm_reg_reg_shift flags x (ishl y (iconst (uimm8 shift))) offset)
+(rule amode_imm_reg_reg_shift_shl_rhs 1 (amode_imm_reg_reg_shift flags x (ishl y (iconst (uimm8 shift))) offset)
         (if (u32_lteq (u8_as_u32 shift) 3))
         (Amode.ImmRegRegShift offset x y shift flags))
-(rule 2 (amode_imm_reg_reg_shift flags (ishl y (iconst (uimm8 shift))) x offset)
+(rule amode_imm_reg_reg_shift_shl_lhs 2 (amode_imm_reg_reg_shift flags (ishl y (iconst (uimm8 shift))) x offset)
         (if (u32_lteq (u8_as_u32 shift) 3))
         (Amode.ImmRegRegShift offset x y shift flags))
 
@@ -1142,6 +1190,7 @@
 (extern constructor amode_offset amode_offset)
 
 ;; Return a zero offset as an `Offset32`.
+(spec (zero_offset) (provide (= result #x00000000)))
 (decl zero_offset () Offset32)
 (extern constructor zero_offset zero_offset)
 
@@ -1594,6 +1643,7 @@
 ;; Put a value into a GPR.
 ;;
 ;; Asserts that the value goes into a GPR.
+(spec (put_in_gpr arg) (provide (= result (conv_to 64 arg))))
 (decl put_in_gpr (Value) Gpr)
 (rule (put_in_gpr val)
       (gpr_new (put_in_reg val)))
@@ -1632,6 +1682,7 @@
 (extern constructor put_in_xmm_mem_imm put_in_xmm_mem_imm)
 
 ;; Construct an `InstOutput` out of a single GPR register.
+(spec (output_gpr x) (provide (= result x)))
 (decl output_gpr (Gpr) InstOutput)
 (rule (output_gpr x)
       (output_reg (gpr_to_reg x)))
@@ -4088,8 +4139,11 @@
             (inst MInst (MInst.Neg size src dst)))
         (ProducesFlags.ProducesFlagsReturnsResultWithConsumer inst dst)))
 
-;; AVH TODO: is SyntheticAmode just the address? 
+;; AVH TODO: is SyntheticAmode just the address?
 ;; Gpr: can we start this as just a new type, modeled as a 64 bit bitvecotr?
+(spec (x64_lea ty amode)
+      (provide (= result amode))
+      (require (or (= ty 32) (= ty 64))))
 (decl x64_lea (Type SyntheticAmode) Gpr)
 (rule (x64_lea ty addr)
       (let ((dst WritableGpr (temp_writable_gpr))

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1013,7 +1013,6 @@
 (decl synthetic_amode_to_reg_mem (SyntheticAmode) RegMem)
 (extern constructor synthetic_amode_to_reg_mem synthetic_amode_to_reg_mem)
 
-;; TODO(mbm): what is the right spec for amode_to_synthetic_amode?
 (spec (amode_to_synthetic_amode amode) (provide (= result amode)))
 (decl amode_to_synthetic_amode (Amode) SyntheticAmode)
 (extern constructor amode_to_synthetic_amode amode_to_synthetic_amode)

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1173,7 +1173,6 @@
             (= (widthof y) 64)
             (= (widthof offset) 32)))
 (decl amode_imm_reg_reg_shift (MemFlags Value Value Offset32) Amode)
-;; TODO: why does this fail to verify? the 0 constant is deduced to have width 1 when 8 is required
 (rule amode_imm_reg_reg_shift_no_shift 0 (amode_imm_reg_reg_shift flags x y offset)
         (Amode.ImmRegRegShift offset x y 0 flags)) ;; 0 == y<<0 == "no shift"
 (rule amode_imm_reg_reg_shift_shl_rhs 1 (amode_imm_reg_reg_shift flags x (ishl y (iconst (uimm8 shift))) offset)

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2,6 +2,8 @@
 
 ;; The main lowering constructor term: takes a clif `Inst` and returns the
 ;; register(s) within which the lowered instruction's result values live.
+(spec (lower arg)
+      (provide (= result arg)))
 (decl partial lower (Inst) InstOutput)
 
 ;; A variant of the main lowering constructor term, used for branches.
@@ -53,7 +55,7 @@
 ;; but the actual instruction emitted might be an `add` if it's equivalent.
 ;; For more details on this see the `emit.rs` logic to emit
 ;; `LoadEffectiveAddress`.
-(rule -5 (lower (has_type (ty_32_or_64 ty) (iadd x y)))
+(rule iadd_base_case_32_or_64_lea -5 (lower (has_type (ty_32_or_64 ty) (iadd x y)))
       (x64_lea ty (to_amode_add (mem_flags_trusted) x y (zero_offset))))
 
 ;; Higher-priority cases than the previous two where a load can be sunk into

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -169,10 +169,6 @@
 
 ;; Pure/fallible constructor that tries to add two `u32`s, interpreted
 ;; as signed values, and fails to match on overflow.
-;;
-;; Note: checked_add() in Rust returns Option<i32>
-;; QUESTION(mbm): how to handle failed match in the spec? is that covered by requires?
-;; BUG: this isn't fallible at all
 (spec (s32_add_fallible x y)
       (provide (= result (bvadd x y)))
       (require (not (bvsaddo x y))))

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -65,6 +65,11 @@
 
 ;; Pure/fallible constructor that tests if one u32 is less than or
 ;; equal to another.
+(spec (u32_lteq  a b)
+    (provide (<= a b)
+             (= (widthof result) 1))
+    (require (= (widthof a) 32)
+             (= (widthof b) 32)))
 (decl pure partial u32_lteq (u32 u32) Unit)
 (extern constructor u32_lteq u32_lteq)
 
@@ -79,10 +84,15 @@
 (extern constructor u8_lt u8_lt)
 
 ;; Get a signed 32-bit immediate in an u32 from an Imm64, if possible.
+(spec (simm32 x) (provide (= result (sign_ext 64 x))))
 (decl simm32 (i32) Imm64)
 (extern extractor simm32 simm32)
 
 ;; Get an unsigned 8-bit immediate in a u8 from an Imm64, if possible.
+(spec (uimm8 arg)
+    (provide (= result (zero_ext 64 arg)))
+    (require (bvslt result #x0000000000000100)
+             (= (widthof arg) 8)))
 (decl uimm8 (u8) Imm64)
 (extern extractor uimm8 uimm8)
 
@@ -91,6 +101,11 @@
 (decl pure u8_as_i8 (u8) i8)
 (extern constructor u8_as_i8 u8_as_i8)
 
+(spec (u8_as_u32 arg)
+    (provide (= result (zero_ext 32 arg)))
+    (require
+      (= (widthof arg) 8)
+      (= (widthof result) 32)))
 (decl pure u8_as_u32 (u8) u32)
 (extern constructor u8_as_u32 u8_as_u32)
 (convert u8 u32 u8_as_u32)
@@ -154,6 +169,13 @@
 
 ;; Pure/fallible constructor that tries to add two `u32`s, interpreted
 ;; as signed values, and fails to match on overflow.
+;;
+;; Note: checked_add() in Rust returns Option<i32>
+;; QUESTION(mbm): how to handle failed match in the spec? is that covered by requires?
+;; BUG: this isn't fallible at all
+(spec (s32_add_fallible x y)
+      (provide (= result (bvadd x y)))
+      (require (not (bvsaddo x y))))
 (decl pure partial s32_add_fallible (i32 i32) i32)
 (extern constructor s32_add_fallible s32_add_fallible)
 
@@ -343,7 +365,13 @@
 
 ;;;; `cranelift_codegen::ir::MemFlags ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; Provide model for the MemFlags type (declared in generated clif_lower.isle).
+(model MemFlags (type (bv 8)))
+
 ;; `MemFlags::trusted`
+;; TODO(mbm): ISLE types for FlagBit (hard-coding #x03 is fragile)
+(spec (mem_flags_trusted)
+      (provide (= result #x03)))
 (decl pure mem_flags_trusted () MemFlags)
 (extern constructor mem_flags_trusted mem_flags_trusted)
 
@@ -403,14 +431,14 @@
 
 ;; An extractor that only matches types that can fit in 16 bits.
 (spec (fits_in_16 arg)
-      (provide (= result arg)) 
+      (provide (= result arg))
       (require (<= arg 16)))
 (decl fits_in_16 (Type) Type)
 (extern extractor fits_in_16 fits_in_16)
 
 ;; An extractor that only matches types that can fit in 32 bits.
 (spec (fits_in_32 arg)
-      (provide (= result arg)) 
+      (provide (= result arg))
       (require (<= arg 32)))
 (decl fits_in_32 (Type) Type)
 (extern extractor fits_in_32 fits_in_32)
@@ -421,7 +449,7 @@
 
 ;; An extractor that only matches types that can fit in 64 bits.
 (spec (fits_in_64 arg)
-      (provide (= result arg)) 
+      (provide (= result arg))
       (require (<= arg 64)))
 (decl fits_in_64 (Type) Type)
 (extern extractor fits_in_64 fits_in_64)
@@ -437,13 +465,16 @@
 ;; A pure constructor/extractor that only matches scalar integers, and
 ;; references that can fit in 64 bits.
 (spec (ty_int_ref_scalar_64 arg)
-    (provide (= result arg)) 
+    (provide (= result arg))
     (require (<= arg 64)))
 (decl pure partial ty_int_ref_scalar_64 (Type) Type)
 (extern constructor ty_int_ref_scalar_64 ty_int_ref_scalar_64)
 (extern extractor ty_int_ref_scalar_64 ty_int_ref_scalar_64_extract)
 
 ;; An extractor that matches 32- and 64-bit types only.
+(spec (ty_32_or_64 arg)
+      (provide (= result arg))
+      (require (or (= arg 32) (= arg 64))))
 (decl ty_32_or_64 (Type) Type)
 (extern extractor ty_32_or_64 ty_32_or_64)
 
@@ -598,10 +629,12 @@
 (extern extractor ty_dyn128_int ty_dyn128_int)
 
 ;; Convert an `Offset32` to a primitive number.
+(spec (offset32_to_i32 offset) (provide (= result offset)))
 (decl pure offset32_to_i32 (Offset32) i32)
 (extern constructor offset32_to_i32 offset32_to_i32)
 
 ;; Convert a number to an `Offset32`
+(spec (i32_to_offset32 x) (provide (= result x)))
 (decl pure i32_to_offset32 (i32) Offset32)
 (extern constructor i32_to_offset32 i32_to_offset32)
 
@@ -612,7 +645,7 @@
 (extern constructor intcc_unsigned intcc_unsigned)
 
 ;; Pure constructor that only matches signed integer cond codes.
-(spec (signed_cond_code c) 
+(spec (signed_cond_code c)
     (provide (= result c))
     (require (and (bvuge c #x02) (bvule c #x05))))
 (decl pure partial signed_cond_code (IntCC) IntCC)

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -65,11 +65,13 @@
 
 ;; Pure/fallible constructor that tests if one u32 is less than or
 ;; equal to another.
-(spec (u32_lteq  a b)
-    (provide (<= a b)
-             (= (widthof result) 1))
-    (require (= (widthof a) 32)
-             (= (widthof b) 32)))
+;; TODO(mbm): when it matches this returns Unit. For now assert a 1-bit value, but what's the right way to handle in provide?
+(spec (u32_lteq a b)
+    (provide (= result #b1))
+    (require (<= a b)
+             (= (widthof a) 32)
+             (= (widthof b) 32)
+             (= (widthof result) 1)))
 (decl pure partial u32_lteq (u32 u32) Unit)
 (extern constructor u32_lteq u32_lteq)
 

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -84,7 +84,9 @@
 (extern constructor u8_lt u8_lt)
 
 ;; Get a signed 32-bit immediate in an u32 from an Imm64, if possible.
-(spec (simm32 x) (provide (= result (sign_ext 64 x))))
+(spec (simm32 x)
+    (provide (= result (sign_ext 64 x)))
+    (require (= (widthof x) 32)))
 (decl simm32 (i32) Imm64)
 (extern extractor simm32 simm32)
 

--- a/cranelift/isle/veri/veri_engine/src/type_inference.rs
+++ b/cranelift/isle/veri/veri_engine/src/type_inference.rs
@@ -1568,7 +1568,7 @@ fn add_rule_constraints(
                 .insert((curr.ident.clone(), curr.type_var));
             let a = annotation_env.get_annotation_for_term(term_id);
             if a.is_none() {
-                println!("\nSkipping rule with unannotated term: {:?}", term_id);
+                println!("\nSkipping rule with unannotated term: {}", term_name);
                 return None;
             }
             let annotation = a.unwrap();

--- a/cranelift/isle/veri/veri_engine/src/widths.rs
+++ b/cranelift/isle/veri/veri_engine/src/widths.rs
@@ -185,6 +185,20 @@ pub fn isle_inst_types() -> HashMap<&'static str, Vec<TermSignature>> {
         ],
     );
 
+    // (decl amode_imm_reg (MemFlags Value Offset32) Amode)
+    widths.insert(
+        "amode_imm_reg",
+        vec![TermSignature {
+            args: vec![
+                Type::BitVector(Some(8)),
+                Type::BitVector(Some(64)),
+                Type::BitVector(Some(32)),
+            ],
+            ret: Type::BitVector(Some(64)),
+            canonical_type: Some(Type::BitVector(Some(64))),
+        }],
+    );
+
     // Binary with possibly differing widths
     widths.insert("rotl", bv_binary_8_to_64.clone());
     widths.insert("rotr", bv_binary_8_to_64.clone());

--- a/cranelift/isle/veri/veri_engine/src/widths.rs
+++ b/cranelift/isle/veri/veri_engine/src/widths.rs
@@ -185,12 +185,42 @@ pub fn isle_inst_types() -> HashMap<&'static str, Vec<TermSignature>> {
         ],
     );
 
+    // (decl to_amode_add (MemFlags Value Value Offset32) Amode)
+    widths.insert(
+        "to_amode_add",
+        vec![TermSignature {
+            args: vec![
+                Type::BitVector(Some(8)),
+                Type::BitVector(Some(64)),
+                Type::BitVector(Some(64)),
+                Type::BitVector(Some(32)),
+            ],
+            ret: Type::BitVector(Some(64)),
+            canonical_type: Some(Type::BitVector(Some(64))),
+        }],
+    );
+
     // (decl amode_imm_reg (MemFlags Value Offset32) Amode)
     widths.insert(
         "amode_imm_reg",
         vec![TermSignature {
             args: vec![
                 Type::BitVector(Some(8)),
+                Type::BitVector(Some(64)),
+                Type::BitVector(Some(32)),
+            ],
+            ret: Type::BitVector(Some(64)),
+            canonical_type: Some(Type::BitVector(Some(64))),
+        }],
+    );
+
+    // (decl amode_imm_reg_reg_shift (MemFlags Value Value Offset32) Amode)
+    widths.insert(
+        "amode_imm_reg_reg_shift",
+        vec![TermSignature {
+            args: vec![
+                Type::BitVector(Some(8)),
+                Type::BitVector(Some(64)),
                 Type::BitVector(Some(64)),
                 Type::BitVector(Some(32)),
             ],

--- a/cranelift/isle/veri/veri_engine/tests/utils/mod.rs
+++ b/cranelift/isle/veri/veri_engine/tests/utils/mod.rs
@@ -243,6 +243,51 @@ pub fn test_aarch64_rule_with_lhs_termname(rulename: &str, termname: &str, tr: T
     test_rules_with_term(inputs, tr, config);
 }
 
+pub fn test_x64_rule_with_lhs_termname_simple(
+    rulename: &str,
+    termname: &str,
+    tr: Vec<(Bitwidth, VerificationResult)>,
+) -> () {
+    test_x64_rule_with_lhs_termname(rulename, termname, TestResult::Simple(tr))
+}
+
+pub fn test_x64_rule_with_lhs_termname(rulename: &str, termname: &str, tr: TestResult) -> () {
+    println!("Verifying rule `{}` with termname {} ", rulename, termname);
+    // TODO(mbm): dedupe with aarch64
+    // TODO(mbm): share configuration with cranelift/codegen/build.rs (or export it as part of build)
+    let cur_dir = env::current_dir().expect("Can't access current working directory");
+    let clif_isle = cur_dir.join("../../../codegen/src").join("inst_specs.isle");
+    let prelude_isle = cur_dir.join("../../../codegen/src").join("prelude.isle");
+    let prelude_lower_isle = cur_dir
+        .join("../../../codegen/src")
+        .join("prelude_lower.isle");
+    let mut inputs = vec![
+        build_clif_lower_isle(),
+        prelude_isle,
+        prelude_lower_isle,
+        clif_isle,
+    ];
+    inputs.push(
+        cur_dir
+            .join("../../../codegen/src/isa/x64")
+            .join("inst.isle"),
+    );
+    inputs.push(
+        cur_dir
+            .join("../../../codegen/src/isa/x64")
+            .join("lower.isle"),
+    );
+    let config = Config {
+        dyn_width: false,
+        term: termname.to_string(),
+        distinct_check: true,
+        custom_verification_condition: None,
+        custom_assumptions: None,
+        names: Some(vec![rulename.to_string()]),
+    };
+    test_rules_with_term(inputs, tr, config);
+}
+
 pub fn test_from_file_with_config_simple(
     file: &str,
     config: Config,

--- a/cranelift/isle/veri/veri_engine/tests/veri.rs
+++ b/cranelift/isle/veri/veri_engine/tests/veri.rs
@@ -4,7 +4,8 @@ use utils::{
     run_and_retry, test_aarch64_rule_with_lhs_termname_simple, test_aarch64_with_config_simple,
     test_concrete_aarch64_rule_with_lhs_termname, test_concrete_input_from_file_with_lhs_termname,
     test_from_file_with_config_simple, test_from_file_with_lhs_termname,
-    test_from_file_with_lhs_termname_simple, Bitwidth, TestResult,
+    test_from_file_with_lhs_termname_simple, test_x64_rule_with_lhs_termname_simple, Bitwidth,
+    TestResult,
 };
 use veri_engine_lib::widths::isle_inst_types;
 use veri_engine_lib::Config;
@@ -3206,4 +3207,149 @@ fn test_broken_imm_udiv_cve_underlying_32() {
             );
         }
     })
+}
+
+// x64
+
+#[test]
+fn test_named_x64_iadd_base_case_32_or_64_lea() {
+    run_and_retry(|| {
+        test_x64_rule_with_lhs_termname_simple(
+            "iadd_base_case_32_or_64_lea",
+            "iadd",
+            vec![(Bitwidth::I64, VerificationResult::Success)],
+        )
+    });
+}
+
+#[test]
+fn test_named_x64_to_amode_add_base_case() {
+    run_and_retry(|| {
+        test_x64_rule_with_lhs_termname_simple(
+            "to_amode_add_base_case",
+            "to_amode_add",
+            vec![(Bitwidth::I64, VerificationResult::Success)],
+        )
+    });
+}
+
+#[test]
+fn test_named_x64_to_amode_add_const_rhs() {
+    run_and_retry(|| {
+        test_x64_rule_with_lhs_termname_simple(
+            "to_amode_add_const_rhs",
+            "to_amode_add",
+            vec![(Bitwidth::I64, VerificationResult::Success)],
+        )
+    });
+}
+
+#[test]
+fn test_named_x64_to_amode_add_const_lhs() {
+    run_and_retry(|| {
+        test_x64_rule_with_lhs_termname_simple(
+            "to_amode_add_const_lhs",
+            "to_amode_add",
+            vec![(Bitwidth::I64, VerificationResult::Success)],
+        )
+    });
+}
+
+#[test]
+fn test_named_x64_to_amode_add_const_fold_iadd_lhs_rhs() {
+    run_and_retry(|| {
+        test_x64_rule_with_lhs_termname_simple(
+            "to_amode_add_const_fold_iadd_lhs_rhs",
+            "to_amode_add",
+            vec![(Bitwidth::I64, VerificationResult::Success)],
+        )
+    });
+}
+
+#[test]
+fn test_named_x64_to_amode_add_const_fold_iadd_lhs_lhs() {
+    run_and_retry(|| {
+        test_x64_rule_with_lhs_termname_simple(
+            "to_amode_add_const_fold_iadd_lhs_lhs",
+            "to_amode_add",
+            vec![(Bitwidth::I64, VerificationResult::Success)],
+        )
+    });
+}
+
+#[test]
+fn test_named_x64_to_amode_add_const_fold_iadd_rhs_rhs() {
+    run_and_retry(|| {
+        test_x64_rule_with_lhs_termname_simple(
+            "to_amode_add_const_fold_iadd_rhs_rhs",
+            "to_amode_add",
+            vec![(Bitwidth::I64, VerificationResult::Success)],
+        )
+    });
+}
+
+#[test]
+fn test_named_x64_to_amode_add_const_fold_iadd_rhs_lhs() {
+    run_and_retry(|| {
+        test_x64_rule_with_lhs_termname_simple(
+            "to_amode_add_const_fold_iadd_rhs_lhs",
+            "to_amode_add",
+            vec![(Bitwidth::I64, VerificationResult::Success)],
+        )
+    });
+}
+
+#[test]
+fn test_named_x64_amode_imm_reg_base() {
+    run_and_retry(|| {
+        test_x64_rule_with_lhs_termname_simple(
+            "amode_imm_reg_base",
+            "amode_imm_reg",
+            vec![(Bitwidth::I64, VerificationResult::Success)],
+        )
+    });
+}
+
+#[test]
+fn test_named_x64_amode_imm_reg_iadd() {
+    run_and_retry(|| {
+        test_x64_rule_with_lhs_termname_simple(
+            "amode_imm_reg_iadd",
+            "amode_imm_reg",
+            vec![(Bitwidth::I64, VerificationResult::Success)],
+        )
+    });
+}
+
+#[test]
+fn test_named_x64_amode_imm_reg_reg_shift_no_shift() {
+    run_and_retry(|| {
+        test_x64_rule_with_lhs_termname_simple(
+            "amode_imm_reg_reg_shift_no_shift",
+            "amode_imm_reg_reg_shift",
+            vec![(Bitwidth::I64, VerificationResult::Success)],
+        )
+    });
+}
+
+#[test]
+fn test_named_x64_amode_imm_reg_reg_shift_shl_rhs() {
+    run_and_retry(|| {
+        test_x64_rule_with_lhs_termname_simple(
+            "amode_imm_reg_reg_shift_shl_rhs",
+            "amode_imm_reg_reg_shift",
+            vec![(Bitwidth::I64, VerificationResult::Success)],
+        )
+    });
+}
+
+#[test]
+fn test_named_x64_amode_imm_reg_reg_shift_shl_lhs() {
+    run_and_retry(|| {
+        test_x64_rule_with_lhs_termname_simple(
+            "amode_imm_reg_reg_shift_shl_lhs",
+            "amode_imm_reg_reg_shift",
+            vec![(Bitwidth::I64, VerificationResult::Success)],
+        )
+    });
 }


### PR DESCRIPTION
Adds specs to verify some of the `Amode` ISLE rules.

Tests:

```
mbm@m1p ~/D/v/v/c/i/v/veri_engine (mbm/x64-veri-amode-init)> cargo test -- named_x64_
...

running 13 tests
test test_named_x64_amode_imm_reg_base ... ok
test test_named_x64_to_amode_add_base_case ... ok
test test_named_x64_amode_imm_reg_reg_shift_no_shift ... ok
test test_named_x64_iadd_base_case_32_or_64_lea ... ok
test test_named_x64_amode_imm_reg_iadd ... ok
test test_named_x64_to_amode_add_const_rhs ... ok
test test_named_x64_to_amode_add_const_lhs ... ok
test test_named_x64_amode_imm_reg_reg_shift_shl_rhs ... ok
test test_named_x64_amode_imm_reg_reg_shift_shl_lhs ... ok
test test_named_x64_to_amode_add_const_fold_iadd_rhs_lhs ... ok
test test_named_x64_to_amode_add_const_fold_iadd_lhs_lhs ... ok
test test_named_x64_to_amode_add_const_fold_iadd_lhs_rhs ... ok
test test_named_x64_to_amode_add_const_fold_iadd_rhs_rhs ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 169 filtered out; finished in 8.23s

   Doc-tests veri_engine_lib

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```