### PR TITLE
Fix broken broken tests

### DIFF
--- a/cranelift/isle/veri/veri_engine/examples/broken/iadd/broken_add_extend.isle
+++ b/cranelift/isle/veri/veri_engine/examples/broken/iadd/broken_add_extend.isle
@@ -38,6 +38,17 @@
     (SXTX #b111)
 ))
 
+(type ExtendOp extern
+  (enum
+    (UXTB)
+    (UXTH)
+    (UXTW)
+    (UXTX)
+    (SXTB)
+    (SXTH)
+    (SXTW)
+    (SXTX)
+))
 
 (decl alu_rr_extend_reg (ALUOp Type Reg ExtendedValue) Reg)
 (extern constructor alu_rr_extend_reg alu_rr_extend_reg)
@@ -68,9 +79,9 @@
 ;; BROKEN: all sign_extend with no zero_extend
 (spec (add_extend ty x y)
     (provide
-      (= result 
+      (= result
          (if (<= ty 32)
-            (conv_to 64 (bvadd (extract 31 0 x) 
+            (conv_to 64 (bvadd (extract 31 0 x)
             (switch (extract 66 64 y)
                   ((ExtendOp.UXTB) (sign_ext 32 (extract 7 0 y)))
                   ((ExtendOp.UXTH) (sign_ext 32 (extract 15 0 y)))
@@ -80,7 +91,7 @@
                   ((ExtendOp.SXTH) (sign_ext 32 (extract 15 0 y)))
                   ((ExtendOp.SXTW) (sign_ext 32 (extract 31 0 y)))
                   ((ExtendOp.SXTX) (sign_ext 32 (extract 31 0 y))))))
-            (bvadd x 
+            (bvadd x
             (switch (extract 66 64 y)
                   ((ExtendOp.UXTB) (sign_ext 64 (extract 7 0 y)))
                   ((ExtendOp.UXTH) (sign_ext 64 (extract 15 0 y)))

--- a/cranelift/isle/veri/veri_engine/examples/broken/iadd/broken_shift.isle
+++ b/cranelift/isle/veri/veri_engine/examples/broken/iadd/broken_shift.isle
@@ -15,15 +15,10 @@
 ;;   01: lsr
 ;;   10: asr
 ;;   11: invalid
-;; the rest will encode a 8-bit shift amount 
+;; the rest will encode a 8-bit shift amount
 (type ShiftOpAndAmt (primitive ShiftOpAndAmt))
 
-(type ALUOp
-  (enum
-    (Add)
-))
-
-(model ALUOp (enum 
+(model ALUOp (enum
       (Add #x00) ;; 0
       (Sub #x01)
       (Orr #x02)
@@ -40,19 +35,36 @@
       (Asr #x0d)
       (Lsl #x0e)))
 
+(type ALUOp (enum
+      (Add)
+      (Sub)
+      (Orr)
+      (OrrNot)
+      (And)
+      (AndNot)
+      (Eor)
+      (EorNot)
+      (SubS)
+      (SDiv)
+      (UDiv)
+      (RotR)
+      (Lsr)
+      (Asr)
+      (Lsl)))
+
 (decl alu_rrr_shift (ALUOp Type Reg Reg ShiftOpAndAmt) Reg)
 (extern constructor alu_rrr_shift alu_rrr_shift)
 
 ;; BROKEN: swapped shl shr
 (spec (add_shift ty a b shift)
-  (provide 
+  (provide
     (= result (if (<= ty 32)
-      (conv_to 64 (bvadd (extract 31 0 a) 
+      (conv_to 64 (bvadd (extract 31 0 a)
       (switch (extract 15 8 shift)
         ((ALUOp.Lsr) (bvshl (extract 31 0 b) (zero_ext 32 (bvand (bvsub (int2bv 8 ty) #x01) (extract 7 0 shift)))))
         ((ALUOp.Lsl) (bvlshr (extract 31 0 b) (zero_ext 32 (bvand (bvsub (int2bv 8 ty) #x01) (extract 7 0 shift)))))
         ((ALUOp.Lsl) (bvashr (extract 31 0 b) (zero_ext 32 (bvand (bvsub (int2bv 8 ty) #x01) (extract 7 0 shift))))))))
-      (bvadd a 
+      (bvadd a
       (switch (extract 15 8 shift)
         ((ALUOp.Lsr) (bvshl b (zero_ext 64 (bvand (bvsub (int2bv 8 ty) #x01) (extract 7 0 shift)))))
         ((ALUOp.Lsl) (bvlshr b (zero_ext 64 (bvand (bvsub (int2bv 8 ty) #x01) (extract 7 0 shift)))))

--- a/cranelift/isle/veri/veri_engine/examples/broken/iadd/broken_shift2.isle
+++ b/cranelift/isle/veri/veri_engine/examples/broken/iadd/broken_shift2.isle
@@ -15,15 +15,10 @@
 ;;   01: lsr
 ;;   10: asr
 ;;   11: invalid
-;; the rest will encode a 8-bit shift amount 
+;; the rest will encode a 8-bit shift amount
 (type ShiftOpAndAmt (primitive ShiftOpAndAmt))
 
-(type ALUOp
-  (enum
-    (Add)
-))
-
-(model ALUOp (enum 
+(model ALUOp (enum
       (Add #x00) ;; 0
       (Sub #x01)
       (Orr #x02)
@@ -40,18 +35,35 @@
       (Asr #x0d)
       (Lsl #x0e)))
 
+(type ALUOp (enum
+      (Add)
+      (Sub)
+      (Orr)
+      (OrrNot)
+      (And)
+      (AndNot)
+      (Eor)
+      (EorNot)
+      (SubS)
+      (SDiv)
+      (UDiv)
+      (RotR)
+      (Lsr)
+      (Asr)
+      (Lsl)))
+
 (decl alu_rrr_shift (ALUOp Type Reg Reg ShiftOpAndAmt) Reg)
 (extern constructor alu_rrr_shift alu_rrr_shift)
 
 (spec (add_shift ty a b shift)
-  (provide 
+  (provide
     (= result (if (<= ty 32)
-      (conv_to 64 (bvadd (extract 31 0 a) 
+      (conv_to 64 (bvadd (extract 31 0 a)
       (switch (extract 15 8 shift)
         ((ALUOp.Lsl) (bvshl (extract 31 0 b) (zero_ext 32 (bvand (bvsub (int2bv 8 ty) #x01) (extract 7 0 shift)))))
         ((ALUOp.Lsr) (bvlshr (extract 31 0 b) (zero_ext 32 (bvand (bvsub (int2bv 8 ty) #x01) (extract 7 0 shift)))))
         ((ALUOp.Asr) (bvashr (extract 31 0 b) (zero_ext 32 (bvand (bvsub (int2bv 8 ty) #x01) (extract 7 0 shift))))))))
-      (bvadd a 
+      (bvadd a
       (switch (extract 15 8 shift)
         ((ALUOp.Lsl) (bvshl b (zero_ext 64 (bvand (bvsub (int2bv 8 ty) #x01) (extract 7 0 shift)))))
         ((ALUOp.Lsr) (bvlshr b (zero_ext 64 (bvand (bvsub (int2bv 8 ty) #x01) (extract 7 0 shift)))))

--- a/cranelift/isle/veri/veri_engine/examples/broken/isub/broken_shift.isle
+++ b/cranelift/isle/veri/veri_engine/examples/broken/isub/broken_shift.isle
@@ -15,10 +15,10 @@
 ;;   01: lsr
 ;;   10: asr
 ;;   11: invalid
-;; the rest will encode a 8-bit shift amount 
+;; the rest will encode a 8-bit shift amount
 (type ShiftOpAndAmt (primitive ShiftOpAndAmt))
 
-(model ALUOp (enum 
+(model ALUOp (enum
       (Add #x00) ;; 0
       (Sub #x01)
       (Orr #x02)
@@ -35,17 +35,30 @@
       (Asr #x0d)
       (Lsl #x0e)))
 
-(type ALUOp
-  (enum
-    (Sub)
-))
+(type ALUOp (enum
+      (Add)
+      (Sub)
+      (Orr)
+      (OrrNot)
+      (And)
+      (AndNot)
+      (Eor)
+      (EorNot)
+      (SubS)
+      (SDiv)
+      (UDiv)
+      (RotR)
+      (Lsr)
+      (Asr)
+      (Lsl)))
+
 
 (decl alu_rrr_shift (ALUOp Type Reg Reg ShiftOpAndAmt) Reg)
 (extern constructor alu_rrr_shift alu_rrr_shift)
 
 ;; BROKEN: swapped shl, shr
-(spec (sub_shift ty a b shift) 
-  (provide 
+(spec (sub_shift ty a b shift)
+  (provide
     (= result (if (<= ty 32)
       (conv_to 64 (bvsub (extract 31 0 a) (switch (extract 15 8 shift)
         ((ALUOp.Lsr) (bvshl (extract 31 0 b) (zero_ext 32 (bvand (bvsub (int2bv 8 ty) #x01) (extract 7 0 shift)))))


### PR DESCRIPTION
Updates some of the "broken" test cases to ensure they have full enum types.

These were failing with errors such as:

```
---- test_broken_iadd_shift2 stdout ----
Verifying iadd rules in file: ./examples/broken/iadd/broken_shift2.isle
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', cranelift/isle/veri/veri_engine/src/annotations.rs:322:85
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'test_broken_iadd_shift2' panicked at 'called `Result::unwrap()` on an `Err` value: Error { error: "Test thread panicked Any { .. }", total_delay: 0ns, tries: 1 }', cranelift/isle/veri/veri_engine/tests/utils/mod.rs:109:12
```

Following the change in #73, we now error if an enum model does not have a corresponding type declaration. This PR fixes the problem by adding full enum type declarations alongside the models.