### PR TITLE
veri: remove type ids from `annotation_ir`

### DIFF
--- a/cranelift/isle/veri/veri_engine/src/type_inference.rs
+++ b/cranelift/isle/veri/veri_engine/src/type_inference.rs
@@ -1142,13 +1142,13 @@ fn add_annotation_constraints(
 
             (veri_ir::Expr::BVExtract(l, r, Box::new(e1)), t)
         }
-        annotation_ir::Expr::BVConcat(xs_) => {
+        annotation_ir::Expr::BVConcat(xs) => {
             // AVH todo: doesn't sum the various widths, has to be done in the solver
             let t = tree.next_type_var;
             tree.next_type_var += 1;
 
             let mut exprs = vec![];
-            for x in xs_ {
+            for x in xs {
                 let (xe, xt) = add_annotation_constraints(x, tree, annotation_info);
                 tree.bv_constraints
                     .insert(TypeExpr::Concrete(xt, annotation_ir::Type::BitVector));

--- a/cranelift/isle/veri/veri_engine/src/type_inference.rs
+++ b/cranelift/isle/veri/veri_engine/src/type_inference.rs
@@ -402,7 +402,7 @@ fn add_annotation_constraints(
             tree.type_var_to_val_map.insert(t, c.value);
             (e, t)
         }
-        annotation_ir::Expr::True(_) => {
+        annotation_ir::Expr::True => {
             let t = tree.next_type_var;
             tree.concrete_constraints
                 .insert(TypeExpr::Concrete(t, annotation_ir::Type::Bool));
@@ -410,7 +410,7 @@ fn add_annotation_constraints(
             tree.next_type_var += 1;
             (veri_ir::Expr::Terminal(veri_ir::Terminal::True), t)
         }
-        annotation_ir::Expr::False(_) => {
+        annotation_ir::Expr::False => {
             let t = tree.next_type_var;
             tree.concrete_constraints
                 .insert(TypeExpr::Concrete(t, annotation_ir::Type::Bool));
@@ -419,7 +419,7 @@ fn add_annotation_constraints(
             (veri_ir::Expr::Terminal(veri_ir::Terminal::False), t)
         }
 
-        annotation_ir::Expr::WidthOf(x, _) => {
+        annotation_ir::Expr::WidthOf(x) => {
             let (ex, tx) = add_annotation_constraints(*x.clone(), tree, annotation_info);
             let t = tree.next_type_var;
             tree.next_type_var += 1;
@@ -431,7 +431,7 @@ fn add_annotation_constraints(
             (veri_ir::Expr::WidthOf(Box::new(ex)), t)
         }
 
-        annotation_ir::Expr::Eq(x, y, _) => {
+        annotation_ir::Expr::Eq(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -446,7 +446,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::Lte(x, y, _) => {
+        annotation_ir::Expr::Lte(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -462,7 +462,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::Not(x, _) => {
+        annotation_ir::Expr::Not(x) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let t = tree.next_type_var;
 
@@ -474,7 +474,7 @@ fn add_annotation_constraints(
             tree.next_type_var += 1;
             (veri_ir::Expr::Unary(veri_ir::UnaryOp::Not, Box::new(e1)), t)
         }
-        annotation_ir::Expr::Or(x, y, _) => {
+        annotation_ir::Expr::Or(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -492,7 +492,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::And(x, y, _) => {
+        annotation_ir::Expr::And(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -511,7 +511,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::BVSgt(x, y, _) => {
+        annotation_ir::Expr::BVSgt(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -527,7 +527,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::BVSgte(x, y, _) => {
+        annotation_ir::Expr::BVSgte(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -543,7 +543,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::BVSlt(x, y, _) => {
+        annotation_ir::Expr::BVSlt(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -559,7 +559,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::BVSlte(x, y, _) => {
+        annotation_ir::Expr::BVSlte(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -575,7 +575,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::BVUgt(x, y, _) => {
+        annotation_ir::Expr::BVUgt(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -591,7 +591,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::BVUgte(x, y, _) => {
+        annotation_ir::Expr::BVUgte(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -607,7 +607,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::BVUlt(x, y, _) => {
+        annotation_ir::Expr::BVUlt(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -623,7 +623,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::BVUlte(x, y, _) => {
+        annotation_ir::Expr::BVUlte(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -639,7 +639,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::BVSaddo(x, y, _) => {
+        annotation_ir::Expr::BVSaddo(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -655,7 +655,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::BVNeg(x, _) => {
+        annotation_ir::Expr::BVNeg(x) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
 
             let t = tree.next_type_var;
@@ -671,7 +671,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVNot(x, _) => {
+        annotation_ir::Expr::BVNot(x) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
 
             let t = tree.next_type_var;
@@ -684,7 +684,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::BVMul(x, y, _) => {
+        annotation_ir::Expr::BVMul(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -705,7 +705,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVUDiv(x, y, _) => {
+        annotation_ir::Expr::BVUDiv(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -726,7 +726,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVSDiv(x, y, _) => {
+        annotation_ir::Expr::BVSDiv(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -747,7 +747,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVAdd(x, y, _) => {
+        annotation_ir::Expr::BVAdd(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -768,7 +768,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVSub(x, y, _) => {
+        annotation_ir::Expr::BVSub(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -789,7 +789,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVUrem(x, y, _) => {
+        annotation_ir::Expr::BVUrem(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -810,7 +810,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVSrem(x, y, _) => {
+        annotation_ir::Expr::BVSrem(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -832,7 +832,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::BVAnd(x, y, _) => {
+        annotation_ir::Expr::BVAnd(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -853,7 +853,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVOr(x, y, _) => {
+        annotation_ir::Expr::BVOr(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -874,7 +874,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVXor(x, y, _) => {
+        annotation_ir::Expr::BVXor(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -895,7 +895,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVRotl(x, a, _) => {
+        annotation_ir::Expr::BVRotl(x, a) => {
             let (xe, xt) = add_annotation_constraints(*x, tree, annotation_info);
             let (ae, at) = add_annotation_constraints(*a, tree, annotation_info);
             let t = tree.next_type_var;
@@ -912,7 +912,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVRotr(x, a, _) => {
+        annotation_ir::Expr::BVRotr(x, a) => {
             let (xe, xt) = add_annotation_constraints(*x, tree, annotation_info);
             let (ae, at) = add_annotation_constraints(*a, tree, annotation_info);
             let t = tree.next_type_var;
@@ -929,7 +929,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVShl(x, a, _) => {
+        annotation_ir::Expr::BVShl(x, a) => {
             let (xe, xt) = add_annotation_constraints(*x, tree, annotation_info);
             let (ae, at) = add_annotation_constraints(*a, tree, annotation_info);
             let t = tree.next_type_var;
@@ -947,7 +947,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVShr(x, a, _) => {
+        annotation_ir::Expr::BVShr(x, a) => {
             let (xe, xt) = add_annotation_constraints(*x, tree, annotation_info);
             let (ae, at) = add_annotation_constraints(*a, tree, annotation_info);
             let t = tree.next_type_var;
@@ -965,7 +965,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVAShr(x, a, _) => {
+        annotation_ir::Expr::BVAShr(x, a) => {
             let (xe, xt) = add_annotation_constraints(*x, tree, annotation_info);
             let (ae, at) = add_annotation_constraints(*a, tree, annotation_info);
             let t = tree.next_type_var;
@@ -983,7 +983,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::Lt(x, y, _) => {
+        annotation_ir::Expr::Lt(x, y) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
             let t = tree.next_type_var;
@@ -999,7 +999,7 @@ fn add_annotation_constraints(
             )
         }
 
-        annotation_ir::Expr::BVConvTo(w, x, _) => {
+        annotation_ir::Expr::BVConvTo(w, x) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let t = tree.next_type_var;
             tree.next_type_var += 1;
@@ -1018,7 +1018,7 @@ fn add_annotation_constraints(
 
             (veri_ir::Expr::BVConvTo(Box::new(e1)), t)
         }
-        annotation_ir::Expr::BVConvToVarWidth(w, x, _) => {
+        annotation_ir::Expr::BVConvToVarWidth(w, x) => {
             let (we, wt) = add_annotation_constraints(*w, tree, annotation_info);
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let t = tree.next_type_var;
@@ -1050,7 +1050,7 @@ fn add_annotation_constraints(
                 )
             }
         }
-        annotation_ir::Expr::BVSignExtToVarWidth(w, x, _) => {
+        annotation_ir::Expr::BVSignExtToVarWidth(w, x) => {
             let (we, wt) = add_annotation_constraints(*w, tree, annotation_info);
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let t = tree.next_type_var;
@@ -1069,7 +1069,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVZeroExtTo(w, x, _) => {
+        annotation_ir::Expr::BVZeroExtTo(w, x) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let t = tree.next_type_var;
             tree.next_type_var += 1;
@@ -1088,7 +1088,7 @@ fn add_annotation_constraints(
 
             (veri_ir::Expr::BVZeroExtTo(width, Box::new(e1)), t)
         }
-        annotation_ir::Expr::BVZeroExtToVarWidth(w, x, _) => {
+        annotation_ir::Expr::BVZeroExtToVarWidth(w, x) => {
             let (we, wt) = add_annotation_constraints(*w, tree, annotation_info);
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let t = tree.next_type_var;
@@ -1107,7 +1107,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVSignExtTo(w, x, _) => {
+        annotation_ir::Expr::BVSignExtTo(w, x) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let t = tree.next_type_var;
 
@@ -1127,7 +1127,7 @@ fn add_annotation_constraints(
 
             (veri_ir::Expr::BVSignExtTo(width, Box::new(e1)), t)
         }
-        annotation_ir::Expr::BVExtract(l, r, x, _) => {
+        annotation_ir::Expr::BVExtract(l, r, x) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let t = tree.next_type_var;
 
@@ -1142,13 +1142,13 @@ fn add_annotation_constraints(
 
             (veri_ir::Expr::BVExtract(l, r, Box::new(e1)), t)
         }
-        annotation_ir::Expr::BVConcat(xs, _) => {
+        annotation_ir::Expr::BVConcat(xs_) => {
             // AVH todo: doesn't sum the various widths, has to be done in the solver
             let t = tree.next_type_var;
             tree.next_type_var += 1;
 
             let mut exprs = vec![];
-            for x in xs {
+            for x in xs_ {
                 let (xe, xt) = add_annotation_constraints(x, tree, annotation_info);
                 tree.bv_constraints
                     .insert(TypeExpr::Concrete(xt, annotation_ir::Type::BitVector));
@@ -1161,7 +1161,7 @@ fn add_annotation_constraints(
 
             (veri_ir::Expr::BVConcat(exprs), t)
         }
-        annotation_ir::Expr::BVIntToBv(w, x, _) => {
+        annotation_ir::Expr::BVIntToBv(w, x) => {
             let (ex, tx) = add_annotation_constraints(*x.clone(), tree, annotation_info);
 
             let t = tree.next_type_var;
@@ -1177,7 +1177,7 @@ fn add_annotation_constraints(
 
             (veri_ir::Expr::BVIntToBV(w, Box::new(ex)), t)
         }
-        annotation_ir::Expr::BVToInt(x, _) => {
+        annotation_ir::Expr::BVToInt(x) => {
             let (ex, tx) = add_annotation_constraints(*x.clone(), tree, annotation_info);
 
             let t = tree.next_type_var;
@@ -1191,7 +1191,7 @@ fn add_annotation_constraints(
 
             (veri_ir::Expr::BVToInt(Box::new(ex)), t)
         }
-        annotation_ir::Expr::Conditional(c, t, e, _) => {
+        annotation_ir::Expr::Conditional(c, t, e) => {
             let (e1, t1) = add_annotation_constraints(*c, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*t, tree, annotation_info);
             let (e3, t3) = add_annotation_constraints(*e, tree, annotation_info);
@@ -1208,7 +1208,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::Switch(c, cases, _) => {
+        annotation_ir::Expr::Switch(c, cases) => {
             let (c_expr, c_t) = add_annotation_constraints(*c, tree, annotation_info);
 
             let t = tree.next_type_var;
@@ -1227,7 +1227,7 @@ fn add_annotation_constraints(
             }
             (veri_ir::Expr::Switch(Box::new(c_expr), case_exprs), t)
         }
-        annotation_ir::Expr::CLZ(x, _) => {
+        annotation_ir::Expr::CLZ(x) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
 
             let t = tree.next_type_var;
@@ -1240,7 +1240,7 @@ fn add_annotation_constraints(
             tree.next_type_var += 1;
             (veri_ir::Expr::CLZ(Box::new(e1)), t)
         }
-        annotation_ir::Expr::A64CLZ(ty, x, _) => {
+        annotation_ir::Expr::A64CLZ(ty, x) => {
             let (e0, t0) = add_annotation_constraints(*ty, tree, annotation_info);
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
 
@@ -1257,7 +1257,7 @@ fn add_annotation_constraints(
             tree.next_type_var += 1;
             (veri_ir::Expr::A64CLZ(Box::new(e0), Box::new(e1)), t)
         }
-        annotation_ir::Expr::CLS(x, _) => {
+        annotation_ir::Expr::CLS(x) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
 
             let t = tree.next_type_var;
@@ -1270,7 +1270,7 @@ fn add_annotation_constraints(
             tree.next_type_var += 1;
             (veri_ir::Expr::CLS(Box::new(e1)), t)
         }
-        annotation_ir::Expr::A64CLS(ty, x, _) => {
+        annotation_ir::Expr::A64CLS(ty, x) => {
             let (e0, t0) = add_annotation_constraints(*ty, tree, annotation_info);
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
 
@@ -1287,7 +1287,7 @@ fn add_annotation_constraints(
             tree.next_type_var += 1;
             (veri_ir::Expr::A64CLS(Box::new(e0), Box::new(e1)), t)
         }
-        annotation_ir::Expr::Rev(x, _) => {
+        annotation_ir::Expr::Rev(x) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
 
             let t = tree.next_type_var;
@@ -1300,7 +1300,7 @@ fn add_annotation_constraints(
             tree.next_type_var += 1;
             (veri_ir::Expr::Rev(Box::new(e1)), t)
         }
-        annotation_ir::Expr::A64Rev(ty, x, _) => {
+        annotation_ir::Expr::A64Rev(ty, x) => {
             let (e0, t0) = add_annotation_constraints(*ty, tree, annotation_info);
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
 
@@ -1317,7 +1317,7 @@ fn add_annotation_constraints(
             tree.next_type_var += 1;
             (veri_ir::Expr::A64Rev(Box::new(e0), Box::new(e1)), t)
         }
-        annotation_ir::Expr::BVSubs(ty, x, y, _) => {
+        annotation_ir::Expr::BVSubs(ty, x, y) => {
             let (e0, t0) = add_annotation_constraints(*ty, tree, annotation_info);
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
             let (e2, t2) = add_annotation_constraints(*y, tree, annotation_info);
@@ -1344,7 +1344,7 @@ fn add_annotation_constraints(
                 t,
             )
         }
-        annotation_ir::Expr::BVPopcnt(x, _) => {
+        annotation_ir::Expr::BVPopcnt(x) => {
             let (e1, t1) = add_annotation_constraints(*x, tree, annotation_info);
 
             let t = tree.next_type_var;

--- a/cranelift/isle/veri/veri_ir/src/annotation_ir.rs
+++ b/cranelift/isle/veri/veri_ir/src/annotation_ir.rs
@@ -29,7 +29,7 @@ impl BoundVar {
 
     /// An expression with the bound variable's name
     pub fn as_expr(&self) -> Expr {
-        Expr::Var(self.name.clone(), 0)
+        Expr::Var(self.name.clone())
     }
 }
 
@@ -153,174 +153,111 @@ pub struct FunctionApplication {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Expr {
     // Terminal nodes
-    Var(String, u32),
-    Const(Const, u32),
-    True(u32),
-    False(u32),
+    Var(String),
+    Const(Const),
+    True,
+    False,
 
     // Get the width of a bitvector
-    WidthOf(Box<Expr>, u32),
+    WidthOf(Box<Expr>),
 
     // Boolean operations
-    Not(Box<Expr>, u32),
-    And(Box<Expr>, Box<Expr>, u32),
-    Or(Box<Expr>, Box<Expr>, u32),
-    Imp(Box<Expr>, Box<Expr>, u32),
-    Eq(Box<Expr>, Box<Expr>, u32),
-    Lte(Box<Expr>, Box<Expr>, u32),
-    Lt(Box<Expr>, Box<Expr>, u32),
+    Not(Box<Expr>),
+    And(Box<Expr>, Box<Expr>),
+    Or(Box<Expr>, Box<Expr>),
+    Imp(Box<Expr>, Box<Expr>),
+    Eq(Box<Expr>, Box<Expr>),
+    Lte(Box<Expr>, Box<Expr>),
+    Lt(Box<Expr>, Box<Expr>),
 
-    BVSgt(Box<Expr>, Box<Expr>, u32),
-    BVSgte(Box<Expr>, Box<Expr>, u32),
-    BVSlt(Box<Expr>, Box<Expr>, u32),
-    BVSlte(Box<Expr>, Box<Expr>, u32),
-    BVUgt(Box<Expr>, Box<Expr>, u32),
-    BVUgte(Box<Expr>, Box<Expr>, u32),
-    BVUlt(Box<Expr>, Box<Expr>, u32),
-    BVUlte(Box<Expr>, Box<Expr>, u32),
+    BVSgt(Box<Expr>, Box<Expr>),
+    BVSgte(Box<Expr>, Box<Expr>),
+    BVSlt(Box<Expr>, Box<Expr>),
+    BVSlte(Box<Expr>, Box<Expr>),
+    BVUgt(Box<Expr>, Box<Expr>),
+    BVUgte(Box<Expr>, Box<Expr>),
+    BVUlt(Box<Expr>, Box<Expr>),
+    BVUlte(Box<Expr>, Box<Expr>),
 
-    BVSaddo(Box<Expr>, Box<Expr>, u32),
+    BVSaddo(Box<Expr>, Box<Expr>),
 
     // Bitvector operations
     //      Note: these follow the naming conventions of the SMT theory of bitvectors:
     //      https://SMT-LIB.cs.uiowa.edu/version1/logics/QF_BV.smt
     // Unary operators
-    BVNeg(Box<Expr>, u32),
-    BVNot(Box<Expr>, u32),
-    CLZ(Box<Expr>, u32),
-    A64CLZ(Box<Expr>, Box<Expr>, u32),
-    CLS(Box<Expr>, u32),
-    A64CLS(Box<Expr>, Box<Expr>, u32),
-    Rev(Box<Expr>, u32),
-    A64Rev(Box<Expr>, Box<Expr>, u32),
-    BVPopcnt(Box<Expr>, u32),
+    BVNeg(Box<Expr>),
+    BVNot(Box<Expr>),
+    CLZ(Box<Expr>),
+    A64CLZ(Box<Expr>, Box<Expr>),
+    CLS(Box<Expr>),
+    A64CLS(Box<Expr>, Box<Expr>),
+    Rev(Box<Expr>),
+    A64Rev(Box<Expr>, Box<Expr>),
+    BVPopcnt(Box<Expr>),
 
     // Binary operators
-    BVMul(Box<Expr>, Box<Expr>, u32),
-    BVUDiv(Box<Expr>, Box<Expr>, u32),
-    BVSDiv(Box<Expr>, Box<Expr>, u32),
-    BVAdd(Box<Expr>, Box<Expr>, u32),
-    BVSub(Box<Expr>, Box<Expr>, u32),
-    BVUrem(Box<Expr>, Box<Expr>, u32),
-    BVSrem(Box<Expr>, Box<Expr>, u32),
-    BVAnd(Box<Expr>, Box<Expr>, u32),
-    BVOr(Box<Expr>, Box<Expr>, u32),
-    BVXor(Box<Expr>, Box<Expr>, u32),
-    BVRotl(Box<Expr>, Box<Expr>, u32),
-    BVRotr(Box<Expr>, Box<Expr>, u32),
-    BVShl(Box<Expr>, Box<Expr>, u32),
-    BVShr(Box<Expr>, Box<Expr>, u32),
-    BVAShr(Box<Expr>, Box<Expr>, u32),
+    BVMul(Box<Expr>, Box<Expr>),
+    BVUDiv(Box<Expr>, Box<Expr>),
+    BVSDiv(Box<Expr>, Box<Expr>),
+    BVAdd(Box<Expr>, Box<Expr>),
+    BVSub(Box<Expr>, Box<Expr>),
+    BVUrem(Box<Expr>, Box<Expr>),
+    BVSrem(Box<Expr>, Box<Expr>),
+    BVAnd(Box<Expr>, Box<Expr>),
+    BVOr(Box<Expr>, Box<Expr>),
+    BVXor(Box<Expr>, Box<Expr>),
+    BVRotl(Box<Expr>, Box<Expr>),
+    BVRotr(Box<Expr>, Box<Expr>),
+    BVShl(Box<Expr>, Box<Expr>),
+    BVShr(Box<Expr>, Box<Expr>),
+    BVAShr(Box<Expr>, Box<Expr>),
 
     // Includes type
-    BVSubs(Box<Expr>, Box<Expr>, Box<Expr>, u32),
+    BVSubs(Box<Expr>, Box<Expr>, Box<Expr>),
 
     // Conversions
     // Zero extend, static and dynamic width
-    BVZeroExtTo(Box<Width>, Box<Expr>, u32),
-    BVZeroExtToVarWidth(Box<Expr>, Box<Expr>, u32),
+    BVZeroExtTo(Box<Width>, Box<Expr>),
+    BVZeroExtToVarWidth(Box<Expr>, Box<Expr>),
 
     // Sign extend, static and dynamic width
-    BVSignExtTo(Box<Width>, Box<Expr>, u32),
-    BVSignExtToVarWidth(Box<Expr>, Box<Expr>, u32),
+    BVSignExtTo(Box<Width>, Box<Expr>),
+    BVSignExtToVarWidth(Box<Expr>, Box<Expr>),
 
     // Extract specified bits
-    BVExtract(usize, usize, Box<Expr>, u32),
+    BVExtract(usize, usize, Box<Expr>),
 
     // Concat two bitvectors
-    BVConcat(Vec<Expr>, u32),
+    BVConcat(Vec<Expr>),
 
     // Convert integer to bitvector
-    BVIntToBv(usize, Box<Expr>, u32),
+    BVIntToBv(usize, Box<Expr>),
 
     // Convert bitvector to integer
-    BVToInt(Box<Expr>, u32),
+    BVToInt(Box<Expr>),
 
     // Conversion to wider/narrower bits, without an explicit extend
-    BVConvTo(Box<Width>, Box<Expr>, u32),
+    BVConvTo(Box<Width>, Box<Expr>),
     // Allow the destination width to be symbolic.
-    BVConvToVarWidth(Box<Expr>, Box<Expr>, u32),
+    BVConvToVarWidth(Box<Expr>, Box<Expr>),
 
     // Conditional if-then-else
-    Conditional(Box<Expr>, Box<Expr>, Box<Expr>, u32),
+    Conditional(Box<Expr>, Box<Expr>, Box<Expr>),
 
     // Switch
-    Switch(Box<Expr>, Vec<(Expr, Expr)>, u32),
+    Switch(Box<Expr>, Vec<(Expr, Expr)>),
 }
 
 impl Expr {
     pub fn var(s: &str) -> Expr {
-        Expr::Var(s.to_string(), 0)
+        Expr::Var(s.to_string())
     }
 
-    pub fn unary<F: Fn(Box<Expr>, u32) -> Expr>(f: F, x: Expr) -> Expr {
-        f(Box::new(x), 0)
+    pub fn unary<F: Fn(Box<Expr>) -> Expr>(f: F, x: Expr) -> Expr {
+        f(Box::new(x))
     }
 
-    pub fn binary<F: Fn(Box<Expr>, Box<Expr>, u32) -> Expr>(f: F, x: Expr, y: Expr) -> Expr {
-        f(Box::new(x), Box::new(y), 0)
-    }
-
-    pub fn get_type_var(x: &Expr) -> u32 {
-        match x {
-            Expr::True(t)
-            | Expr::False(t)
-            | Expr::Var(_, t)
-            | Expr::Const(_, t)
-            | Expr::WidthOf(_, t)
-            | Expr::Not(_, t)
-            | Expr::BVNeg(_, t)
-            | Expr::BVNot(_, t)
-            | Expr::CLZ(_, t)
-            | Expr::A64CLZ(_, _, t)
-            | Expr::CLS(_, t)
-            | Expr::A64CLS(_, _, t)
-            | Expr::Rev(_, t)
-            | Expr::A64Rev(_, _, t)
-            | Expr::And(_, _, t)
-            | Expr::Or(_, _, t)
-            | Expr::Imp(_, _, t)
-            | Expr::Eq(_, _, t)
-            | Expr::Lte(_, _, t)
-            | Expr::BVSgt(_, _, t)
-            | Expr::BVSgte(_, _, t)
-            | Expr::BVSlt(_, _, t)
-            | Expr::BVSlte(_, _, t)
-            | Expr::BVUgt(_, _, t)
-            | Expr::BVUgte(_, _, t)
-            | Expr::BVUlt(_, _, t)
-            | Expr::BVUlte(_, _, t)
-            | Expr::BVMul(_, _, t)
-            | Expr::BVUDiv(_, _, t)
-            | Expr::BVSDiv(_, _, t)
-            | Expr::BVAdd(_, _, t)
-            | Expr::BVSub(_, _, t)
-            | Expr::BVUrem(_, _, t)
-            | Expr::BVSrem(_, _, t)
-            | Expr::BVAnd(_, _, t)
-            | Expr::BVOr(_, _, t)
-            | Expr::BVXor(_, _, t)
-            | Expr::BVRotl(_, _, t)
-            | Expr::BVRotr(_, _, t)
-            | Expr::BVShl(_, _, t)
-            | Expr::BVShr(_, _, t)
-            | Expr::BVAShr(_, _, t)
-            | Expr::BVSaddo(_, _, t)
-            | Expr::Lt(_, _, t)
-            | Expr::BVZeroExtTo(_, _, t)
-            | Expr::BVZeroExtToVarWidth(_, _, t)
-            | Expr::BVSignExtTo(_, _, t)
-            | Expr::BVSignExtToVarWidth(_, _, t)
-            | Expr::BVIntToBv(_, _, t)
-            | Expr::BVToInt(_, t)
-            | Expr::BVConvTo(_, _, t)
-            | Expr::BVConvToVarWidth(_, _, t)
-            | Expr::BVExtract(_, _, _, t)
-            | Expr::BVConcat(_, t)
-            | Expr::BVSubs(_, _, _, t)
-            | Expr::BVPopcnt(_, t)
-            | Expr::Conditional(_, _, _, t)
-            | Expr::Switch(_, _, t) => *t,
-        }
+    pub fn binary<F: Fn(Box<Expr>, Box<Expr>) -> Expr>(f: F, x: Expr, y: Expr) -> Expr {
+        f(Box::new(x), Box::new(y))
     }
 }


### PR DESCRIPTION
This PR removes the type ID fields from `annotation_ir` types. They are
currently all set to 0 and unused, so their presence ends up being a bit
confusing. I think it's better to delete them if they're not used.
