### PR TITLE
veri: fix bug in BVShr type inference

### DIFF
--- a/cranelift/isle/veri/veri_engine/src/solver.rs
+++ b/cranelift/isle/veri/veri_engine/src/solver.rs
@@ -707,12 +707,12 @@ impl SolverCtx {
 
                         // Width math
                         if self.dynwidths {
-                            if self.onlywidths {
-                                return xs;
-                            }
                             // The shift arg needs to be extracted to the right width, default to 8 if unknown
                             let y_static_width = self.static_width(&y).unwrap_or(8);
                             let y_rec = self.vir_expr_to_sexp(*y);
+                            if self.onlywidths {
+                                return xs;
+                            }
                             let extract = self.smt.extract(
                                 y_static_width.checked_sub(1).unwrap().try_into().unwrap(),
                                 0,


### PR DESCRIPTION
This PR fixes a bug in the Solver in dynamic width mode and `onlywidths` true,
where the `y` operand of a `BVShr` expression will not be visited. This can
cause type inference to fail. This problem came up when trying to use a
Sail-generated specification that contained a `concat` expression in the
right-hand-side operand.
