### PR TITLE
veri: set `MAX_WIDTH` to `2*REG_WIDTH`

### DIFF
--- a/cranelift/isle/veri/veri_engine/src/lib.rs
+++ b/cranelift/isle/veri/veri_engine/src/lib.rs
@@ -16,7 +16,7 @@ pub mod verify;
 pub const REG_WIDTH: usize = 64;
 
 // Use a distinct with as the maximum width any value should have within type inference
-pub const MAX_WIDTH: usize = 4*REG_WIDTH;
+pub const MAX_WIDTH: usize = 2 * REG_WIDTH;
 
 pub const FLAGS_WIDTH: usize = 4;
 


### PR DESCRIPTION
This PR sets `MAX_WIDTH` to twice `REG_WIDTH`, which is big enough for now and
gives a meaningful performance improvement.

Running `cargo test -- --test-threads=1` before:
```
test result: ok. 172 passed; 0 failed; 10 ignored; 0 measured; 0 filtered out; finished in 271.79s
```
After:
```
test result: ok. 172 passed; 0 failed; 10 ignored; 0 measured; 0 filtered out; finished in 170.34s
```
