### PR TITLE
veri: use cranelift-codegen all-arch feature

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -9,7 +9,7 @@ use crate::binemit::{Addend, CodeOffset, Reloc};
 pub use crate::ir::condcodes::IntCC;
 use crate::ir::types::{self, F32, F64, I128, I16, I32, I64, I8, I8X16, R32, R64};
 
-pub use crate::ir::{ExternalName, MemFlags, Opcode, SourceLoc, Type, ValueLabel};
+pub use crate::ir::{ExternalName, MemFlags, Opcode, Type};
 use crate::isa::{CallConv, FunctionAlignment};
 use crate::machinst::*;
 use crate::{settings, CodegenError, CodegenResult};

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -13,6 +13,7 @@ use crate::isa::riscv64::lower::args::{
     FReg, VReg, WritableFReg, WritableVReg, WritableXReg, XReg,
 };
 use crate::isa::riscv64::Riscv64Backend;
+use crate::isa::unwind::UnwindInst;
 use crate::machinst::Reg;
 use crate::machinst::{isle::*, MachInst};
 use crate::machinst::{VCodeConstant, VCodeConstantData};

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -7,12 +7,13 @@ use std::cell::Cell;
 pub use super::MachLabel;
 use super::RetPair;
 pub use crate::ir::{
-    condcodes, condcodes::CondCode, dynamic_to_fixed, Constant, DynamicStackSlot, ExternalName,
-    FuncRef, GlobalValue, Immediate, SigRef, StackSlot,
+    condcodes, condcodes::CondCode, dynamic_to_fixed, ArgumentExtension, Constant,
+    DynamicStackSlot, ExternalName, FuncRef, GlobalValue, Immediate, SigRef, StackSlot,
 };
 pub use crate::isa::TargetIsa;
 pub use crate::machinst::{
-    ABIArg, ABIArgSlot, Lower, LowerBackend, RealReg, Reg, RelocDistance, Sig, VCodeInst, Writable,
+    ABIArg, ABIArgSlot, InputSourceInst, Lower, LowerBackend, RealReg, Reg, RelocDistance, Sig,
+    VCodeInst, Writable,
 };
 pub use crate::settings::TlsModel;
 

--- a/cranelift/isle/veri/veri_engine/Cargo.toml
+++ b/cranelift/isle/veri/veri_engine/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 cranelift-isle = { path = "../../isle" }
-cranelift-codegen = { path = "../../../codegen" }
+cranelift-codegen = { path = "../../../codegen", features = ["all-arch"] }
 cranelift-codegen-meta = { path = "../../../codegen/meta" }
 veri_ir = { path = "../veri_ir" }
 easy-smt = { git = "https://github.com/elliottt/easy-smt.git" }


### PR DESCRIPTION
This PR enables the `all-arch` feature for our dependency on the
`cranelift-codegen` crate.

I suspect this was the cause of confusing errors related to unused imports in
the codegen crate. By default `cranelift-codegen` only includes the host
architecture. Therefore, when switching from x86 to aarch64 (Linux workstation
to Apple laptop) it was possible that the build would work on one but not the
other.
